### PR TITLE
new function to eliminate clades from species names

### DIFF
--- a/MARS/main.py
+++ b/MARS/main.py
@@ -1,12 +1,15 @@
 from MARS.utils import merge_files, normalize_dataframes, save_dataframes, combine_metrics
-from MARS.operations import split_taxonomic_groups, rename_taxa, calculate_metrics, check_presence_in_agora2
+from MARS.operations import remove_clades_from_speciesNames, split_taxonomic_groups, rename_taxa, calculate_metrics, check_presence_in_agora2
 import pandas as pd
 import os
 
 def process_microbial_abundances(input_file1, input_file2, output_path=None, cutoff=None, output_format="csv", stratification_file=None, flagLoneSpecies=False, taxaSplit="; "):
     print(taxaSplit, flagLoneSpecies, cutoff)
     merged_dataframe = merge_files(input_file1, input_file2)
-    taxonomic_dataframes = split_taxonomic_groups(merged_dataframe, flagLoneSpecies=flagLoneSpecies, taxaSplit=taxaSplit)
+    # Added new function "remove_clades_from_speciesNames" in operations.py - JW
+    merged_dataframe_woClades = remove_clades_from_speciesNames(merged_dataframe)
+    taxonomic_dataframes = split_taxonomic_groups(merged_dataframe_woClades, flagLoneSpecies=flagLoneSpecies, taxaSplit=taxaSplit)
+
     renamed_dataframes = rename_taxa(taxonomic_dataframes)
     present_dataframes, absent_dataframes = check_presence_in_agora2(renamed_dataframes)
     normalized_dataframes = normalize_dataframes(renamed_dataframes, cutoff=cutoff)

--- a/MARS/main.py
+++ b/MARS/main.py
@@ -1,13 +1,13 @@
 from MARS.utils import merge_files, normalize_dataframes, save_dataframes, combine_metrics
-from MARS.operations import remove_clades_from_speciesNames, split_taxonomic_groups, rename_taxa, calculate_metrics, check_presence_in_agora2
+from MARS.operations import remove_clades_from_taxaNames, split_taxonomic_groups, rename_taxa, calculate_metrics, check_presence_in_agora2
 import pandas as pd
 import os
 
 def process_microbial_abundances(input_file1, input_file2, output_path=None, cutoff=None, output_format="csv", stratification_file=None, flagLoneSpecies=False, taxaSplit="; "):
     print(taxaSplit, flagLoneSpecies, cutoff)
     merged_dataframe = merge_files(input_file1, input_file2)
-    # Added new function "remove_clades_from_speciesNames" in operations.py - JW
-    merged_dataframe_woClades = remove_clades_from_speciesNames(merged_dataframe)
+    # Added new function "remove_clades_from_taxaNames" in operations.py - JW
+    merged_dataframe_woClades = remove_clades_from_taxaNames(merged_dataframe)
     taxonomic_dataframes = split_taxonomic_groups(merged_dataframe_woClades, flagLoneSpecies=flagLoneSpecies, taxaSplit=taxaSplit)
 
     renamed_dataframes = rename_taxa(taxonomic_dataframes)

--- a/MARS/operations.py
+++ b/MARS/operations.py
@@ -2,13 +2,57 @@ import pandas as pd
 import json
 import os
 import numpy as np
+import re
+
+# Added new function to remove the clade identifier in the species names,
+# integrating matlab standalone code from Bram into the python MARS pipeline - JW
+def remove_clades_from_speciesNames(merged_df):
+    """ 
+    Remove clade extensions from species names and sums counts of all clades of a species together.
+
+    Args:
+        merged_df (pd.DataFrame): The input DataFrame with taxonomic groups in the index.
+    
+    Returns:
+        grouped_df (pd.DataFrame): The input DataFrame with taxonomic groups in the index, without clade seperation anymore.
+    """
+    merged_df = merged_df.reset_index()
+    taxa = merged_df['Taxon']
+
+    # Filter taxa that contain ';s__' & split the strings by ';'
+    taxaSpecies = taxa[taxa.str.contains(';s__')]
+    taxaSpeciesSplit = taxaSpecies.str.split(';', expand=True)
+
+    # Extract species from the 7th column (species column)
+    species = taxaSpeciesSplit[6].astype(str)
+
+    # Clean species names using regex
+    species = species.str.replace(r'_[A-Z]$', '', regex=True)
+    species = species.str.replace(r'_[A-Z]\s', '', regex=True)
+
+    # Update taxa with cleaned species
+    taxaUpdate = pd.concat([taxaSpeciesSplit.iloc[:, :6], species], axis=1)
+    taxaUpdate = taxaUpdate.apply(lambda x: ';'.join(x.astype(str)), axis=1)
+
+    # Replace original taxa with updated taxa & update the merged_df
+    taxa[taxa.str.contains(';s__')] = taxaUpdate.values
+    merged_df['Taxon'] = taxa
+
+    # Group by 'Taxon' and sum, remove 'GroupCount' column if it exists &
+    # rename columns to remove 'sum_' prefix
+    grouped_df = merged_df.groupby('Taxon').sum().reset_index()
+    if 'GroupCount' in grouped_df.columns:
+        grouped_df.drop(columns='GroupCount', inplace=True)
+    grouped_df.columns = [col.replace('sum_', '') for col in grouped_df.columns]
+
+    return grouped_df
 
 def split_taxonomic_groups(merged_df, flagLoneSpecies=False, taxaSplit='; '):
     """
     Split the taxonomic groups in the index of the input DataFrame and create separate DataFrames for each taxonomic level.
 
     Args:
-        merged_df (pd.DataFrame): The input DataFrame with taxonomic groups in the index.
+        merged_df (pd.DataFrame): The input DataFrame with taxonomic groups in the index, without clade seperation anymore.
 
     Returns:
         dict: A dictionary with keys as taxonomic levels and values as the corresponding DataFrames.
@@ -17,7 +61,10 @@ def split_taxonomic_groups(merged_df, flagLoneSpecies=False, taxaSplit='; '):
     levels = ['Kingdom', 'Phylum', 'Class', 'Order', 'Family', 'Genus', 'Species']
 
     # Replace all level indicators in the 'Taxon' column
-    merged_df = merged_df.reset_index()
+    # Added drop=True argument as indexing of merged_df is reset within 
+    # remove_clades_from_speciesNames function - JW
+    merged_df = merged_df.reset_index(drop=True)
+    
     merged_df['Taxon'] = merged_df['Taxon'].replace(".__", "", regex=True)
     print(taxaSplit)
     # Reset the index and split the index column into separate columns for each taxonomic level
@@ -166,10 +213,19 @@ def calculate_metrics(dataframes, group=None):
             # Calculate phylum distribution
             phylum_distribution = df.groupby(df.index.name).sum()
 
+            # Replace altenative naming of Bacteroidetes to allow for
+            # ratio calculation - JW
+            phylum_distribution = phylum_distribution.rename({'Bacteroidota':'Bacteroidetes'}, axis='index')
+
             # Calculate Firmicutes to Bacteroidetes ratio
             firmicutes = phylum_distribution.loc['Firmicutes'] if 'Firmicutes' in phylum_distribution.index else 0
             bacteroidetes = phylum_distribution.loc['Bacteroidetes'] if 'Bacteroidetes' in phylum_distribution.index else 0
-            fb_ratio = firmicutes / bacteroidetes
+            # Added if statement for unlikely condition bacteroidetes are not present
+            # in microbiome dataset to avoid "division by 0" error - JW
+            if 'Bacteroidetes' in phylum_distribution.index:
+                fb_ratio = firmicutes / bacteroidetes
+            else:
+                fb_ratio = 0
 
             level_metrics.update({
                 'firmicutes_bacteroidetes_ratio': fb_ratio,

--- a/MARS/operations.py
+++ b/MARS/operations.py
@@ -197,12 +197,16 @@ def calculate_metrics(dataframes, group=None):
     for level, df in dataframes.items():
         if group is not None:
             df = df[group]
-            
+        
         # Calculate read counts
         read_counts = df.sum()
 
         # Calculate alpha diversity using the Shannon index
-        shannon_index = -1 * (df * df.apply(np.log)).sum()
+        # Found small error in shannon_index calculation (needs rel.abundances
+        # as input instead of absolute readcounts per species). Added df with
+        # rel. abundances and calculated shannon_index from there - JW
+        rel_abundances = df.div(read_counts)
+        shannon_index = -1 * (rel_abundances * rel_abundances.apply(np.log)).sum()
 
         level_metrics = {
             'read_counts': read_counts,


### PR DESCRIPTION
Added new function to operations.py which deletes clade extensions from species names & phyla names and sums their rel.abundances per species (extended and adapted standalone matlab script from Bram to Python and integrated into the MARS pipeline).
Two small additional changes added in operations.py for the ratio calculation of firmicutes/bacteroidetes:
1. Added if statement to avoid divison by zero error in case there would be no bacteroidetes present in microbiome dataset.
2. Added renaming statement for "Bacteroidota" into "Bacteriodetes" to be recognnized by ratio calculation function.

UPDATE:
Found a small error in shannon diversity index calculation (was taking absolute read-counts for calculation instead of rel.abundances, which would be correct). I corrected the shannon_index equation in operations.py to now take rel.abundances as input.

UPDATE2:
Clade removement from phyla is now part of above mentioned function.
Firmicutes are present in AGORA2 as "Bacillota", therefore Firmicutes are renamed before AGORA2 mapping and new name is used for indexing for firmicutes/bacteriodetes ratio calculation.