### PR TITLE
Dir names updates for MARS results

### DIFF
--- a/MARS/main.py
+++ b/MARS/main.py
@@ -99,9 +99,9 @@ def process_microbial_abundances(input_file1, input_file2, output_path=None, cut
 
     # Step 9: Store all result dataframes in a structure & save, if output-path is provided
     dataframe_groups = {'normalized_preMapped': preMapped_dataframes_normalized, 
-                        'normalized_presentPostMapped_adjForModelling': present_dataframes_adjForModelling,
-                        'normalized_presentPostMapped': present_dataframes_normalized,
-                        'normalized_absentPostMapped': absent_dataframes_normalized,
+                        'renormalized_mapped_forModelling': present_dataframes_adjForModelling,
+                        'normalized_mapped': present_dataframes_normalized,
+                        'normalized_unmapped': absent_dataframes_normalized,
                         'metrics': [combined_metrics, combined_summ_stats, \
                                     pre_mapping_abundance_metrics, \
                                    present_post_mapping_abundance_metrics, \

--- a/MARS/utils.py
+++ b/MARS/utils.py
@@ -361,7 +361,7 @@ def save_dataframes(dataframe_groups, output_path, output_format):
                 level_output_path = os.path.join(group_output_path, level)
                 os.makedirs(level_output_path, exist_ok=True)
 
-                file_name = f"postMapping_present_abundanceMetrics_{level}.{output_format}"
+                file_name = f"mapped_abundanceMetrics_{level}.{output_format}"
                 file_path = os.path.join(level_output_path, file_name)
 
                 if output_format == "csv":
@@ -385,7 +385,7 @@ def save_dataframes(dataframe_groups, output_path, output_format):
                 level_output_path = os.path.join(group_output_path, level)
                 os.makedirs(level_output_path, exist_ok=True)
 
-                file_name = f"postMapping_absent_abundanceMetrics_{level}.{output_format}"
+                file_name = f"unmapped_abundanceMetrics_{level}.{output_format}"
                 file_path = os.path.join(level_output_path, file_name)
 
                 if output_format == "csv":
@@ -427,7 +427,7 @@ def save_dataframes(dataframe_groups, output_path, output_format):
                 level_output_path = os.path.join(group_output_path, level)
                 os.makedirs(level_output_path, exist_ok=True)
 
-                file_name = f"postMapping_present_brayCurtisDissimilarity_{level}.{output_format}"
+                file_name = f"mapped_brayCurtisDissimilarity_{level}.{output_format}"
                 file_path = os.path.join(level_output_path, file_name)
 
                 if output_format == "csv":
@@ -448,7 +448,7 @@ def save_dataframes(dataframe_groups, output_path, output_format):
                 level_output_path = os.path.join(group_output_path, level)
                 os.makedirs(level_output_path, exist_ok=True)
 
-                file_name = f"postMapping_absent_brayCurtisDissimilarity_{level}.{output_format}"
+                file_name = f"unmapped_brayCurtisDissimilarity_{level}.{output_format}"
                 file_path = os.path.join(level_output_path, file_name)
 
                 if output_format == "csv":
@@ -538,7 +538,7 @@ def save_dataframes(dataframe_groups, output_path, output_format):
                 level_output_path = os.path.join(group_output_path, level)
                 os.makedirs(level_output_path, exist_ok=True)
 
-                file_name = f"postMapping_abundanceMetrics_{level}_stratified.{output_format}"
+                file_name = f"mapped_abundanceMetrics_{level}_stratified.{output_format}"
                 file_path = os.path.join(level_output_path, file_name)
 
                 if output_format == "csv":


### PR DESCRIPTION
Updated dir names for MARS output for easier seperation between dirs (especially to differentiate, which dataframe was normalized in which way).
New structure:
- normalized_preMapped (pre mapped taxa dataframe normalized against pre mapped dataframe)
- renormalized_mapped_forModelling (post mapped present taxa dataframe normalized against post mapped present taxa dataframe ->this one is the input for modelling)
- normalized_mapped (post mapped present taxa dataframe normalized against pre mapped taxa dataframe)
- normalized_unmapped (post mapped absent taxa dataframe normalized against pre mapped taxa dataframe)
- metrics (contains all metrices)